### PR TITLE
Fix timestamp field for imported offers

### DIFF
--- a/app/Console/Commands/ScrapeRecyclingPrices.php
+++ b/app/Console/Commands/ScrapeRecyclingPrices.php
@@ -7,6 +7,7 @@ use App\Models\Device;
 use App\Models\Offer;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\File;
+use Carbon\Carbon;
 
 class ScrapeRecyclingPrices extends Command
 {
@@ -63,7 +64,7 @@ class ScrapeRecyclingPrices extends Command
                             'condition' => $offer['condition'],
                             'network' => $offer['network'],
                             'source' => $sourceName,
-                            'timestamp' => now(),
+                            'timestamp' => isset($offer['timestamp']) ? Carbon::parse($offer['timestamp']) : now(),
                         ]);
                     }
                 }


### PR DESCRIPTION
## Summary
- record the scraped timestamp when importing JSON offers

## Testing
- `php artisan test` *(fails: `php: command not found`)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846c73f497c832e989b0f2983f00e44