### PR TITLE
Add CleanBrand unit tests

### DIFF
--- a/tests/Unit/CleanBrandTest.php
+++ b/tests/Unit/CleanBrandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use App\Console\Commands\ScrapeRecyclingPrices;
+use ReflectionMethod;
+
+class CleanBrandTest extends TestCase
+{
+    /**
+     * @dataProvider brandProvider
+     */
+    public function test_clean_brand(string $input, string $expected): void
+    {
+        $method = new ReflectionMethod(ScrapeRecyclingPrices::class, 'cleanBrand');
+        $method->setAccessible(true);
+        $this->assertSame($expected, $method->invoke(null, $input));
+    }
+
+    public static function brandProvider(): array
+    {
+        return [
+            ['THE MOBILE SHOP', 'Mobile shop'],
+            ['BUY TEK', ''],
+            ['SAMSUNG MOBILES', 'Samsung'],
+            ['ACME PHONES', 'Acme'],
+            ['THE great phone SHOP', 'Great phone'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add new `CleanBrandTest` verifying brand sanitization logic

## Testing
- `composer test` *(fails: command not found)*
- `./vendor/bin/phpunit --testsuite Unit` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d4d49af4832ea8b1b47d017ae5f1