### PR TITLE
Create marketing layout for landing page

### DIFF
--- a/resources/views/layouts/marketing.blade.php
+++ b/resources/views/layouts/marketing.blade.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+
+        <title>{{ config('app.name', 'Laravel') }}</title>
+
+        <!-- Fonts -->
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+
+        <!-- Scripts -->
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+    </head>
+    <body class="font-sans antialiased text-gray-900">
+        @yield('content')
+    </body>
+</html>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,19 +1,55 @@
-<x-guest-layout>
-    <div class="flex items-center justify-center min-h-screen bg-gradient-to-r from-emerald-100 via-lime-100 to-emerald-50 py-12 px-6">
-        <div class="text-center max-w-xl p-8 bg-white shadow rounded-lg">
-            <div class="mb-6">
-                <x-application-logo class="w-24 h-24 mx-auto text-emerald-600" />
-            </div>
-            <h1 class="text-4xl font-bold mb-4 text-gray-800">Welcome to {{ config('app.name', 'Laravel') }}</h1>
-            <p class="text-gray-600 mb-8">Manage recycling data easily and efficiently with our platform.</p>
-            @if (Route::has('login'))
+@extends('layouts.marketing')
+
+@section('content')
+<div class="min-h-screen flex flex-col">
+    <header class="bg-emerald-600 text-white">
+        <div class="max-w-7xl mx-auto px-6 py-16 grid md:grid-cols-2 gap-8 items-center">
+            <div>
+                <h1 class="text-4xl font-bold mb-4">{{ config('app.name') }}</h1>
+                <p class="mb-6">Manage recycling data easily and efficiently with our platform.</p>
                 <div class="space-x-4">
-                    <a href="{{ route('login') }}" class="px-4 py-2 bg-emerald-600 text-white rounded hover:bg-emerald-700">Log in</a>
+                    <a href="{{ route('login') }}" class="px-4 py-2 bg-white text-emerald-600 rounded font-semibold">Log in</a>
                     @if (Route::has('register'))
-                        <a href="{{ route('register') }}" class="px-4 py-2 border border-emerald-600 text-emerald-600 rounded hover:bg-emerald-50">Register</a>
+                        <a href="{{ route('register') }}" class="px-4 py-2 border border-white rounded font-semibold">Register</a>
                     @endif
                 </div>
-            @endif
+            </div>
+            <div class="text-center">
+                <img src="https://via.placeholder.com/800x400?text=Screenshot" alt="App screenshot" class="mx-auto rounded shadow">
+            </div>
         </div>
-    </div>
-</x-guest-layout>
+    </header>
+
+    <section class="py-16 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-6">
+            <h2 class="text-2xl font-bold text-center mb-12">Features</h2>
+            <div class="grid md:grid-cols-3 gap-8">
+                <div class="p-6 bg-white shadow rounded">
+                    <h3 class="font-semibold mb-2">Easy Data Entry</h3>
+                    <p class="text-sm text-gray-600">Quickly log recycling activity with intuitive forms.</p>
+                </div>
+                <div class="p-6 bg-white shadow rounded">
+                    <h3 class="font-semibold mb-2">Reports</h3>
+                    <p class="text-sm text-gray-600">Visualize your impact through detailed reports.</p>
+                </div>
+                <div class="p-6 bg-white shadow rounded">
+                    <h3 class="font-semibold mb-2">Community Sharing</h3>
+                    <p class="text-sm text-gray-600">Share successes and tips with other users.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="py-16">
+        <div class="max-w-3xl mx-auto text-center">
+            <h2 class="text-3xl font-bold mb-4">Ready to get started?</h2>
+            <div class="space-x-4">
+                <a href="{{ route('login') }}" class="px-6 py-3 bg-emerald-600 text-white rounded font-semibold">Log in</a>
+                @if (Route::has('register'))
+                    <a href="{{ route('register') }}" class="px-6 py-3 border border-emerald-600 text-emerald-600 rounded font-semibold">Register</a>
+                @endif
+            </div>
+        </div>
+    </section>
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- add marketing layout for public pages
- redesign welcome page using hero section with placeholder image, features list and call-to-action
- remove local screenshot to avoid binary file issues

## Testing
- `php artisan serve` *(fails: `php: command not found`)*
- `composer test` *(fails: `composer: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed42cbd4832e827c4f38f3d12b8f